### PR TITLE
unquote after decoding json

### DIFF
--- a/xcall.py
+++ b/xcall.py
@@ -177,11 +177,14 @@ class XCallClient(object):
                 'Try xcall directly from terminal with: "%s"' % ' '.join(args))
 
         if stdout:
-            response = urllib.parse.unquote(stdout.decode('utf8'))
             if self.json_decode_success:
-                return json.loads(response)
+                result = json.loads(stdout.decode('utf8'))
+                for element in result:
+                    if result[element]:
+                        result[element] = urllib.parse.unquote(result[element])
+                return result
             else:
-                return response
+                return urllib.parse.unquote(stdout.decode('utf8'))
         elif stderr:
             self.on_xerror_handler(stderr, url)
 


### PR DESCRIPTION
Nice work here!  This was just the thing I was looking for :smile:

I found that the xcall results parser was unable to deal with notes containing strings like: `https://example.com&param=%22abcd%22`  because the unquoted string is invalid json.  This PR does the json decoding first, and then unquotes the elements of the resulting json object.